### PR TITLE
Consider `org.droidtv.playtv` as tv app

### DIFF
--- a/philips_2016.py
+++ b/philips_2016.py
@@ -320,7 +320,7 @@ class PhilipsTVBase(object):
             if rr:
                 pkgName = rr.get('component', {}).get('packageName')
                 className = rr.get('component', {}).get('className')
-                if pkgName == 'org.droidtv.zapster' or pkgName == 'NA':
+                if pkgName == 'org.droidtv.zapster' or pkgName == 'org.droidtv.playtv' or pkgName == 'NA':
                     self.media_content_type = 'channel'
                     r = self._getReq('activities/tv')
                     if r:


### PR DESCRIPTION
I'm using a philips POS9002 Tv and `activities/current` returns the following response when playing TV:
```json
{
    "component": {
        "packageName": "org.droidtv.playtv",
        "className": "org.droidtv.playtv.PlayTvActivity"
    }
}
```