### PR TITLE
Allow configuration of the WOL broadcast IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Key | Type | Required | Description
 `host` | `string` | `True` | The IP of the TV
 `mac` | `string` | `False` | The MAC of the TV (Wifi MAC required for WoWLAN)
 `favorite_channels_only` | `boolean` | `False` | Enable/disable only showing the favorite channels
+`wol_broadcast_ip` | `string` | `False` | Change the brodcast IP address for the WOL packet
 
 ## Special requirements for turning the TV back on from Standby
 Essentially wake-on-lan wakes up the API part of the TV. Then the TV is able to receive a command to set the power state to on.

--- a/example.yaml
+++ b/example.yaml
@@ -6,3 +6,4 @@ media_player:
     username: xxxxx
     password: xxxxx
     favorite_channels_only: false
+    wol_broadcast_ip: '192.168.1.255'


### PR DESCRIPTION
This PR exposes the WOL broadcast IP address option from the python `wakeonlan` library through a HA configuration variable. This allows users to define a different network segment to target for their WOL packet.

This is useful to me as I am running HA container and do not use host mode networking.

